### PR TITLE
Bugfix/show two digits pieces in hand

### DIFF
--- a/lib/src/widgets/piece_in_hand.dart
+++ b/lib/src/widgets/piece_in_hand.dart
@@ -62,7 +62,7 @@ class PieceInHand extends StatelessWidget {
         ),
         if (count > 1)
           Container(
-            width: size * _countContainerSizeMultiplier,
+            width: size * _countContainerSizeMultiplier * (count > 9 ? 2 : 1),
             height: size * _countContainerSizeMultiplier,
             alignment: isSente ? Alignment.topRight : Alignment.bottomLeft,
             child: RotatedBox(


### PR DESCRIPTION
Fixes a bug where in the case of the count of a piece in hand being above 9, the second digit would be cut off.