### PR TITLE
Feature/pieces in hand align piece color player icon color

### DIFF
--- a/lib/src/widgets/shogi_board.dart
+++ b/lib/src/widgets/shogi_board.dart
@@ -215,9 +215,6 @@ class _PiecesInHand extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final playerIconColor = Theme.of(context).brightness == Brightness.dark
-        ? Colors.white
-        : Colors.black;
     final playerIconSize = size * _sizeMultiplier;
 
     return SizedBox(
@@ -231,7 +228,7 @@ class _PiecesInHand extends StatelessWidget {
             PlayerIcon(
               isSente: isSente,
               size: playerIconSize,
-              color: playerIconColor,
+              color: pieceColor,
             ),
           Row(
             mainAxisAlignment:
@@ -255,7 +252,7 @@ class _PiecesInHand extends StatelessWidget {
                 PlayerIcon(
                   isSente: isSente,
                   size: playerIconSize,
-                  color: playerIconColor,
+                  color: pieceColor,
                 ),
                 SizedBox(width: rightEdgeSpacer)
               ],


### PR DESCRIPTION
* Use piece color instead of theme brightness to style player icon.
* This not only enforces consistency but can avoid issues where brightness and piece color may differ.